### PR TITLE
feat: add configurable hook filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ questions:
     type: bool
     help: Will your project include tests?
     default: true
+
+  pre_hook_filename:
+    type: str
+    help: Name of the pre-hook script file
+    default: "pre"
+
+  post_hook_filename:
+    type: str
+    help: Name of the post-hook script file
+    default: "post"
 ```
 
 The values of the `help` and `default` keys can include templates for value substitution. Each subsequent question has access to the answers of the previous ones as demonstrated in `project_author` and `project_slug`.
@@ -268,8 +278,8 @@ Baker executes hooks as separate processes, which makes them language-independen
 
 For a hook to be executed, it must meet two requirements:
 
-1. It must be located in the template directory `template_root/hooks/` and named either `post` or `pre`.
-2. It must be an executable file (`chmod +x template_root/hooks/post`).
+1. It must be located in the template directory `template_root/hooks/` and named according to the `pre_hook_filename` or `post_hook_filename` specified in the configuration.
+2. It must be an executable file (`chmod +x template_root/hooks/<hook_filename>`).
 
 When generating a project containing a hook, Baker will issue a warning:
 
@@ -347,7 +357,40 @@ graph LR
     class stdin2,stdin3,stdout1,stdout3 stream
 ```
 
-There is an example [example](examples/hooks) of a simple template using a post-hook: it reads the user's response for the selected license, retrieves the corresponding license content from the available license files, and writes it to the target directory as the `LICENSE` file.
+### Customizing Hook Filenames
+
+By default, Baker looks for hook scripts named `pre` and `post` in the `hooks` directory of your template. You can customize these filenames using the `pre_hook_filename` and `post_hook_filename` configuration options in your `baker.yaml` file:
+
+```yaml
+schemaVersion: v1
+
+questions:
+  # Your regular questions here...
+
+# Custom hook filenames
+pre_hook_filename: "setup-environment"
+post_hook_filename: "finalize-project"
+```
+
+With this configuration, Baker will:
+
+1. Look for a pre-hook script at `template_root/hooks/setup-environment`
+2. Look for a post-hook script at `template_root/hooks/finalize-project`
+
+This is useful when:
+
+- You want more descriptive hook filenames
+- You need different hooks for different templates in the same repository
+- You're integrating with existing scripts that follow a different naming convention
+
+The warning prompt will show the actual filenames:
+
+```
+WARNING: This template contains the following hooks that will execute commands on your system:
+examples/hooks/hooks/setup-environment
+examples/hooks/hooks/finalize-project
+Do you want to run these hooks? [y/N]
+```
 
 ## Questions
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,9 +157,15 @@ pub fn run(args: Args) -> Result<()> {
         &template_root,
         args.skip_confirms.contains(&crate::cli::SkipConfirm::All)
             || args.skip_confirms.contains(&crate::cli::SkipConfirm::Hooks),
+        &config.pre_hook_filename,
+        &config.post_hook_filename,
     )?;
 
-    let (pre_hook_file, post_hook_file) = get_hook_files(&template_root);
+    let (pre_hook_file, post_hook_file) = get_hook_files(
+        &template_root,
+        &config.pre_hook_filename,
+        &config.post_hook_filename,
+    );
 
     // Execute pre-generation hook
     let pre_hook_stdout = if execute_hooks && pre_hook_file.exists() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,18 @@ pub struct Question {
 pub struct ConfigV1 {
     #[serde(default)]
     pub questions: IndexMap<String, Question>,
+    #[serde(default = "get_default_post_hook_filename")]
+    pub post_hook_filename: String,
+    #[serde(default = "get_default_pre_hook_filename")]
+    pub pre_hook_filename: String,
+}
+
+fn get_default_post_hook_filename() -> String {
+    "post".to_string()
+}
+
+fn get_default_pre_hook_filename() -> String {
+    "pre".to_string()
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -42,11 +42,15 @@ pub fn get_path_if_exists<P: AsRef<Path>>(path: P) -> String {
 ///
 /// # Returns
 /// * `(PathBuf, PathBuf)` - Tuple containing paths to pre and post hook scripts
-pub fn get_hook_files<P: AsRef<Path>>(template_dir: P) -> (PathBuf, PathBuf) {
+pub fn get_hook_files<P: AsRef<Path>>(
+    template_dir: P,
+    pre_hook_filename: &str,
+    post_hook_filename: &str,
+) -> (PathBuf, PathBuf) {
     let template_dir = template_dir.as_ref();
     let hooks_dir = template_dir.join("hooks");
 
-    (hooks_dir.join("pre"), hooks_dir.join("post"))
+    (hooks_dir.join(pre_hook_filename), hooks_dir.join(post_hook_filename))
 }
 
 /// Executes a hook script with the provided context.
@@ -112,8 +116,11 @@ pub fn run_hook<P: AsRef<Path>>(
 pub fn confirm_hook_execution<P: AsRef<Path>>(
     template_dir: P,
     skip_hooks_check: bool,
+    pre_hook_filename: &str,
+    post_hook_filename: &str,
 ) -> Result<bool> {
-    let (pre_hook_file, post_hook_file) = get_hook_files(template_dir);
+    let (pre_hook_file, post_hook_file) =
+        get_hook_files(template_dir, pre_hook_filename, post_hook_filename);
     if pre_hook_file.exists() || post_hook_file.exists() {
         Ok(confirm(
             skip_hooks_check,


### PR DESCRIPTION
This commit introduces the ability to customize hook filenames in Baker templates through the configuration file. Previously, hook files were hardcoded to be named "pre" and "post", which limited flexibility when working with multiple templates or when integrating with existing scripts.

Changes include:
- Added `pre_hook_filename` and `post_hook_filename` configuration options to the ConfigV1 struct with default values of "pre" and "post" respectively
- Updated hook-related functions to accept these custom filenames instead of using hardcoded values
- Updated the CLI code to pass the configured filenames to the hook execution functions
- Added documentation in the README explaining the new configuration options and providing examples of usage

The default behavior remains unchanged to maintain backward compatibility with existing templates.