### PR TITLE
feat: enhances error reporting and debugging

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,8 +159,16 @@ pub fn run(args: Args) -> Result<()> {
 
     add_templates_in_renderer(&template_root, &config, engine.as_mut());
 
-    let pre_hook_filename = engine.render(&config.pre_hook_filename, &json!({}))?;
-    let post_hook_filename = engine.render(&config.post_hook_filename, &json!({}))?;
+    let pre_hook_filename = engine.render(
+        &config.pre_hook_filename,
+        &json!({}),
+        Some(&config.pre_hook_filename),
+    )?;
+    let post_hook_filename = engine.render(
+        &config.post_hook_filename,
+        &json!({}),
+        Some(&config.post_hook_filename),
+    )?;
 
     let execute_hooks = confirm_hook_execution(
         &template_root,

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,7 +192,7 @@ impl Question {
         } else if let Some(default_str) = default.as_str() {
             // If it's a string, try to render it as a template first
             let rendered_str =
-                engine.render(default_str, answers).unwrap_or(default_str.to_string());
+                engine.render(default_str, answers, Some("default_value")).unwrap_or(default_str.to_string());
 
             // Parse the string based on the question type
             match question_type {
@@ -236,7 +236,7 @@ impl Question {
                     // Trying to render given string.
                     // Otherwise returns an empty string.
                     let default_rendered =
-                        engine.render(default_str, answers).unwrap_or_default();
+                        engine.render(default_str, answers, Some("default_value")).unwrap_or_default();
                     serde_json::Value::String(default_rendered)
                 }
                 QuestionType::Json | QuestionType::Yaml => self
@@ -251,7 +251,7 @@ impl Question {
 
         // Sometimes "help" contain the value with the template strings.
         // This function renders it and returns rendered value.
-        let help = engine.render(&self.help, answers).unwrap_or(self.help.clone());
+        let help = engine.render(&self.help, answers, Some("help")).unwrap_or(self.help.clone());
 
         let ask_if = engine.execute_expression(&self.ask_if, answers).unwrap_or(true);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,8 +191,9 @@ impl Question {
             default
         } else if let Some(default_str) = default.as_str() {
             // If it's a string, try to render it as a template first
-            let rendered_str =
-                engine.render(default_str, answers, Some("default_value")).unwrap_or(default_str.to_string());
+            let rendered_str = engine
+                .render(default_str, answers, Some("default_value"))
+                .unwrap_or(default_str.to_string());
 
             // Parse the string based on the question type
             match question_type {
@@ -235,8 +236,9 @@ impl Question {
 
                     // Trying to render given string.
                     // Otherwise returns an empty string.
-                    let default_rendered =
-                        engine.render(default_str, answers, Some("default_value")).unwrap_or_default();
+                    let default_rendered = engine
+                        .render(default_str, answers, Some("default_value"))
+                        .unwrap_or_default();
                     serde_json::Value::String(default_rendered)
                 }
                 QuestionType::Json | QuestionType::Yaml => self
@@ -251,7 +253,8 @@ impl Question {
 
         // Sometimes "help" contain the value with the template strings.
         // This function renders it and returns rendered value.
-        let help = engine.render(&self.help, answers, Some("help")).unwrap_or(self.help.clone());
+        let help =
+            engine.render(&self.help, answers, Some("help")).unwrap_or(self.help.clone());
 
         let ask_if = engine.execute_expression(&self.ask_if, answers).unwrap_or(true);
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -27,10 +27,16 @@ pub trait TemplateRenderer {
     /// # Arguments
     /// * `template` - Template string to render
     /// * `context` - Context variables for rendering
+    /// * `template_name` - Optional name for the template (used in error messages)
     ///
     /// # Returns
     /// * `Result<String>` - Rendered template string
-    fn render(&self, template: &str, context: &serde_json::Value) -> Result<String>;
+    fn render(
+        &self,
+        template: &str,
+        context: &serde_json::Value,
+        template_name: Option<&str>,
+    ) -> Result<String>;
 
     /// Renders a path with the given context.
     ///
@@ -108,9 +114,11 @@ impl MiniJinjaRenderer {
         &self,
         template: &str,
         context: &serde_json::Value,
+        template_name: Option<&str>,
     ) -> Result<String> {
         let mut env = self.env.clone();
-        env.add_template("temp", template)?;
+        let name = template_name.unwrap_or("temp");
+        env.add_template(name, template)?;
 
         // Merge the default context with the provided context
         let merged_context = if let (Some(default_obj), Some(context_obj)) =
@@ -126,7 +134,7 @@ impl MiniJinjaRenderer {
             context.clone()
         };
 
-        let tmpl = env.get_template("temp")?;
+        let tmpl = env.get_template(name)?;
         Ok(tmpl.render(merged_context)?)
     }
 }
@@ -148,8 +156,13 @@ impl TemplateRenderer for MiniJinjaRenderer {
         self.env.add_template_owned(normalized_name, template.to_string())
     }
 
-    fn render(&self, template: &str, context: &serde_json::Value) -> Result<String> {
-        self.render_internal(template, context)
+    fn render(
+        &self,
+        template: &str,
+        context: &serde_json::Value,
+        template_name: Option<&str>,
+    ) -> Result<String> {
+        self.render_internal(template, context, template_name)
     }
 
     fn render_path(
@@ -158,7 +171,9 @@ impl TemplateRenderer for MiniJinjaRenderer {
         context: &serde_json::Value,
     ) -> Result<String> {
         let path_str = path_to_str(template_path)?;
-        self.render_internal(path_str, context)
+        let template_name =
+            template_path.file_name().and_then(|name| name.to_str()).map(|s| s.as_ref());
+        self.render_internal(path_str, context, template_name)
     }
 
     fn execute_expression(

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -171,8 +171,7 @@ impl TemplateRenderer for MiniJinjaRenderer {
         context: &serde_json::Value,
     ) -> Result<String> {
         let path_str = path_to_str(template_path)?;
-        let template_name =
-            template_path.file_name().and_then(|name| name.to_str()).map(|s| s.as_ref());
+        let template_name = template_path.file_name().and_then(|name| name.to_str());
         self.render_internal(path_str, context, template_name)
     }
 

--- a/src/template/processor.rs
+++ b/src/template/processor.rs
@@ -179,7 +179,10 @@ impl<'a, P: AsRef<Path>> TemplateProcessor<'a, P> {
             // Template file
             (true, true) => {
                 let template_content = fs::read_to_string(&template_entry)?;
-                let content = self.engine.render(&template_content, self.answers)?;
+                let template_name =
+                    template_entry.file_name().and_then(|name| name.to_str());
+                let content =
+                    self.engine.render(&template_content, self.answers, template_name)?;
 
                 Ok(TemplateOperation::Write {
                     target: self.remove_template_suffix(&target_path)?,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -57,7 +57,11 @@ pub fn validate_answer(
 
             if !is_valid {
                 let error_message = engine
-                    .render(&question.validation.error_message, answers, Some("validation_error"))
+                    .render(
+                        &question.validation.error_message,
+                        answers,
+                        Some("validation_error"),
+                    )
                     .unwrap_or_else(|_| "Validation failed".to_string());
                 return Err(ValidationError::FieldValidation(error_message));
             }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -57,7 +57,7 @@ pub fn validate_answer(
 
             if !is_valid {
                 let error_message = engine
-                    .render(&question.validation.error_message, answers)
+                    .render(&question.validation.error_message, answers, Some("validation_error"))
                     .unwrap_or_else(|_| "Validation failed".to_string());
                 return Err(ValidationError::FieldValidation(error_message));
             }

--- a/tests/renderer_tests.rs
+++ b/tests/renderer_tests.rs
@@ -7,7 +7,7 @@ mod tests {
 
     fn test_template(template: &str, expected: &str) {
         let renderer = MiniJinjaRenderer::new();
-        let result = renderer.render(template, &json!({})).unwrap();
+        let result = renderer.render(template, &json!({}), None).unwrap();
         assert_eq!(result, expected);
     }
 
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn test_regex_filter_invalid_regex() {
         let renderer = MiniJinjaRenderer::new();
-        let result = renderer.render("{{ 'hello' | regex('[') }}", &json!({}));
+        let result = renderer.render("{{ 'hello' | regex('[') }}", &json!({}), None);
         assert_eq!(result.unwrap(), "false");
     }
 


### PR DESCRIPTION
The `render` method now accepts an optional template name parameter that gets passed through to the underlying template engine, allowing for more precise error messages when template rendering fails.

Logs example

```
...
[2025-06-22T20:17:21Z ERROR baker::cli] Template rendering failed: syntax error: unexpected `}`, expected end of variable block (in example.txt.baker.j2:2)
...
Template generation completed successfully in out.
```