### PR TITLE
fix: use inline format args to resolve clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,13 +194,12 @@ pub fn run(args: Args) -> Result<()> {
 
     if let Some(result) = pre_hook_stdout {
         log::debug!(
-            "Pre-hook stdout content (attempting to parse as JSON answers): {}",
-            result
+            "Pre-hook stdout content (attempting to parse as JSON answers): {result}"
         );
 
         let pre_answers = serde_json::from_str::<serde_json::Value>(&result).map_or_else(
             |e| {
-                log::warn!("Failed to parse hook output as JSON: {}", e);
+                log::warn!("Failed to parse hook output as JSON: {e}");
                 serde_json::Map::new()
             },
             |value| match value {
@@ -246,7 +245,7 @@ pub fn run(args: Args) -> Result<()> {
                 Ok(answer) => answer,
                 Err(err) => match err {
                     Error::JSONParseError(_) | Error::YAMLParseError(_) => {
-                        println!("{}", err);
+                        println!("{err}");
                         continue;
                     }
                     _ => return Err(err),
@@ -259,8 +258,8 @@ pub fn run(args: Args) -> Result<()> {
             match validate_answer(&question, &answer, engine.as_ref(), &_answers) {
                 Ok(_) => break,
                 Err(err) => match err {
-                    ValidationError::JsonSchema(msg) => println!("{}", msg),
-                    ValidationError::FieldValidation(msg) => println!("{}", msg),
+                    ValidationError::JsonSchema(msg) => println!("{msg}"),
+                    ValidationError::FieldValidation(msg) => println!("{msg}"),
                 },
             }
         }
@@ -321,11 +320,11 @@ pub fn run(args: Args) -> Result<()> {
                 };
 
                 let message = file_operation.get_message(user_confirmed_overwrite);
-                log::info!("{}", message);
+                log::info!("{message}");
             }
             Err(e) => match e {
-                Error::ProcessError { .. } => log::warn!("{}", e),
-                _ => log::error!("{}", e),
+                Error::ProcessError { .. } => log::warn!("{e}"),
+                _ => log::error!("{e}"),
             },
         }
     }
@@ -337,7 +336,7 @@ pub fn run(args: Args) -> Result<()> {
             run_hook(&template_root, &output_root, &post_hook_file, Some(&answers))?;
 
         if let Some(result) = post_hook_stdout {
-            log::debug!("Post-hook stdout content: {}", result);
+            log::debug!("Post-hook stdout content: {result}");
         }
     }
 

--- a/src/dialoguer.rs
+++ b/src/dialoguer.rs
@@ -111,7 +111,7 @@ fn prompt_for_input_method(prompt: &str, default_method: usize) -> Result<usize>
     let methods = vec!["Use text editor", "Enter inline"];
 
     let selection = Select::new()
-        .with_prompt(format!("{} - Choose input method", prompt))
+        .with_prompt(format!("{prompt} - Choose input method"))
         .default(default_method)
         .items(&methods)
         .interact()?;
@@ -121,7 +121,7 @@ fn prompt_for_input_method(prompt: &str, default_method: usize) -> Result<usize>
 
 /// Handle multiline console input for structured data
 fn get_data_from_console(is_yaml: bool, prompt: &str) -> Result<serde_json::Value> {
-    println!("{} (Enter empty line to finish):", prompt);
+    println!("{prompt} (Enter empty line to finish):");
     let mut lines = Vec::new();
     loop {
         let line: String =

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,6 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// Default error handler that prints the error message and exits with code 1
 pub fn default_error_handler(err: Error) {
-    eprintln!("Error: {}", err);
+    eprintln!("Error: {err}");
     std::process::exit(1);
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -44,7 +44,7 @@ pub fn add_templates_in_renderer(
                     .map(|content| (rel_path_str.to_owned(), content))
             })
             .for_each(|(filename, content)| {
-                debug!("Adding template: {}", filename);
+                debug!("Adding template: {filename}");
                 engine.add_template(&filename, &content).unwrap();
             });
     } else {
@@ -77,7 +77,7 @@ pub fn build_templates_import_globset(
     for pattern in patterns {
         let path_to_ignored_pattern = template_root.join(pattern);
         let path_str = path_to_str(&path_to_ignored_pattern).unwrap_or_else(|_| {
-            debug!("Failed to convert path to string: {:?}", path_to_ignored_pattern);
+            debug!("Failed to convert path to string: {path_to_ignored_pattern:?}");
             ""
         });
         builder.add(Glob::new(path_str).unwrap());

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for TemplateSource {
             TemplateSource::FileSystem(path) => {
                 write!(f, "local path: '{}'", path.display())
             }
-            TemplateSource::Git(repo) => write!(f, "git repository: '{}'", repo),
+            TemplateSource::Git(repo) => write!(f, "git repository: '{repo}'"),
         }
     }
 }
@@ -194,7 +194,7 @@ impl<S: AsRef<str>> TemplateLoader for GitLoader<S> {
     fn load(&self) -> Result<PathBuf> {
         let repo_url = self.repo.as_ref();
 
-        log::debug!("Cloning repository '{}'", repo_url);
+        log::debug!("Cloning repository '{repo_url}'");
 
         let repo_name = Self::extract_repo_name(repo_url);
         let clone_path = PathBuf::from(&repo_name);
@@ -202,7 +202,7 @@ impl<S: AsRef<str>> TemplateLoader for GitLoader<S> {
         if clone_path.exists() {
             let response = confirm(
                 self.skip_overwrite_check,
-                format!("Directory '{}' already exists. Replace it?", repo_name),
+                format!("Directory '{repo_name}' already exists. Replace it?"),
             )?;
             if response {
                 fs::remove_dir_all(&clone_path)?;
@@ -223,7 +223,7 @@ impl<S: AsRef<str>> TemplateLoader for GitLoader<S> {
             git2::Cred::ssh_key(
                 username_from_url.unwrap_or("git"),
                 None,
-                std::path::Path::new(&format!("{}/.ssh/id_rsa", home)),
+                std::path::Path::new(&format!("{home}/.ssh/id_rsa")),
                 None,
             )
         });

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -76,7 +76,7 @@ fn regex_filter(val: &str, re: &str) -> bool {
     match Regex::new(re) {
         Ok(re) => re.is_match(val),
         Err(err) => {
-            warn!("Invalid regex '{}': {}", re, err);
+            warn!("Invalid regex '{re}': {err}");
             false
         }
     }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -44,8 +44,7 @@ pub fn validate_answer(
             if let Some(schema) = &question.schema {
                 validate_with_schema(answer, schema).map_err(|e| {
                     ValidationError::JsonSchema(format!(
-                        "JSON Schema validation error: {}",
-                        e
+                        "JSON Schema validation error: {e}"
                     ))
                 })?;
             }


### PR DESCRIPTION
Replace format!("{}", var) with format!("{var}") syntax across all source files to fix clippy::uninlined_format_args warnings and ensure compatibility with Rust 1.88.0.