### PR TITLE
fix(cli,prompt): correct default log level and choice index handling

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,7 +23,7 @@ const HELP_TEMPLATE: &str = r#"{about-section}
 /// Get the appropriate log level from verbose count
 pub fn get_log_level_from_verbose(verbose_count: u8) -> LevelFilter {
     match verbose_count {
-        verbosity::OFF => LevelFilter::Off, // Default level when no -v flags
+        verbosity::OFF => LevelFilter::Error, // Default level when no -v flags
         verbosity::INFO => LevelFilter::Info, // -v
         verbosity::DEBUG => LevelFilter::Debug, // -vv
         verbosity::TRACE.. => LevelFilter::Trace, // -vvv and beyond


### PR DESCRIPTION
- Change default log level from Off to Error in CLI module
- Fix prompt handler logic to properly handle index 0 as valid default
- Add comprehensive test for default choice index behavior
- Ensure first choice can be properly selected as default

Fixes issues where:
- No logs were shown when no verbose flags were provided
- Default choice at index 0 was incorrectly treated as no default