### PR TITLE
feat: add support for answers file

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -58,6 +58,10 @@ pub struct Args {
     #[arg(short, long)]
     pub answers: Option<String>,
 
+    /// Path to a JSON file containing predefined answers.
+    #[arg(long = "answers-file", value_name = "FILE")]
+    pub answers_file: Option<PathBuf>,
+
     /// Confirmation prompts to skip (comma-separated).
     #[arg(long = "skip-confirms", value_delimiter = ',')]
     #[arg(value_enum)]
@@ -154,5 +158,20 @@ mod tests {
         assert!(args.skip_confirms.contains(&SkipConfirm::Overwrite));
         assert!(args.non_interactive);
         assert!(args.dry_run);
+    }
+
+    #[test]
+    fn parses_answers_file_argument() {
+        use clap::Parser;
+        let args = Args::parse_from([
+            "baker",
+            "template_dir",
+            "output_dir",
+            "--answers-file",
+            "/path/to/answers.json",
+        ]);
+        assert_eq!(args.template, "template_dir");
+        assert_eq!(args.output_dir, PathBuf::from("output_dir"));
+        assert_eq!(args.answers_file, Some(PathBuf::from("/path/to/answers.json")));
     }
 }

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -186,7 +186,12 @@ impl Runner {
     ) -> Result<serde_json::Value> {
         let collector =
             AnswerCollector::new(engine, self.args.non_interactive, template_root);
-        collector.collect_answers(config, pre_hook_output, self.args.answers.clone())
+        collector.collect_answers(
+            config,
+            pre_hook_output,
+            self.args.answers.clone(),
+            self.args.answers_file.clone(),
+        )
     }
 
     /// Processes all template files
@@ -480,6 +485,7 @@ mod tests {
             force: false,
             verbose: 0,
             answers: None,
+            answers_file: None,
             skip_confirms: Vec::new(),
             non_interactive: false,
             dry_run: false,

--- a/tests/gitea_integration_tests.rs
+++ b/tests/gitea_integration_tests.rs
@@ -672,6 +672,7 @@ fn test_jsonschema_file_template_from_gitea() {
         force: true,
         verbose: 2,
         answers: None,
+        answers_file: None,
         skip_confirms: vec![All],
         non_interactive: true,
         dry_run: false,

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -102,6 +102,7 @@ pub fn run_and_assert(template: &str, expected_dir: &str, answers: Option<&str>)
         force: true,
         verbose: 2,
         answers: answers.map(|a| a.to_string()),
+        answers_file: None,
         skip_confirms: vec![All],
         non_interactive: true,
         dry_run: false,


### PR DESCRIPTION
In CLI add argument --answers-file for loading predefined answers from a JSON file.